### PR TITLE
QAIBT-470 Erro ao Executar projeto (F11) com Bloco Agendar Execução vinculado ao Evento de "Ao Iniciar Sistema".

### DIFF
--- a/src/main/java/cronapi/RestClient.java
+++ b/src/main/java/cronapi/RestClient.java
@@ -166,10 +166,10 @@ public class RestClient {
 
 	public HttpServletRequest getRequest() {
 		if (request != null) {
-		  return request;
-    } else {
-      return((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
-    }
+			return request;
+		} else {
+			return RequestContextHolder.getRequestAttributes() != null ? ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest() : null;
+		}
 	}
 
   public void setResponse(HttpServletResponse response) {
@@ -177,11 +177,11 @@ public class RestClient {
   }
 
 	public HttpServletResponse getResponse() {
-    if (response != null) {
-      return response;
-    } else {
-      return((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getResponse();
-    }
+		if (response != null) {
+			return response;
+		} else {
+			return RequestContextHolder.getRequestAttributes() != null ? ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getResponse() : null;
+		}
 	}
 
 	public String getParameter(String key) {

--- a/src/test/java/br/com/cronapi/RestClientTest.java
+++ b/src/test/java/br/com/cronapi/RestClientTest.java
@@ -1,0 +1,17 @@
+package br.com.cronapi;
+
+import cronapi.RestClient;
+import org.testng.annotations.Test;
+
+public class RestClientTest {
+
+    @Test
+    public void checkGetRequest() {
+        RestClient.getRestClient().getRequest();
+    }
+
+    @Test
+    public void checkGetResponse() {
+        RestClient.getRestClient().getResponse();
+    }
+}


### PR DESCRIPTION
- Otimizando o comportamento da classe RestClient (getRequest() e getResponse()).