### PR TITLE
CRONAPP-1524 - Bloco math_arithmetic não retorna decimais

### DIFF
--- a/src/main/java/cronapi/math/Operations.java
+++ b/src/main/java/cronapi/math/Operations.java
@@ -125,25 +125,16 @@ public class Operations {
 	}
 
 	public static final Var divisor(Var... values) throws Exception {
-		boolean isDouble = false;
-		for (Var v : values)
-			if (v.getType() == Var.Type.DOUBLE)
-				isDouble = true;
-		if (isDouble) {
-			Double result = values[0].getObjectAsDouble();
+		Double result = Var.valueOf(0).getObjectAsDouble();
+		for (Var v : values) {
+			result = values[0].getObjectAsDouble();
 			values[0] = new Var(1);
 			for (Var value : values) {
 				result = result / value.getObjectAsDouble();
 			}
 			return new Var(result);
-		} else {
-			Long result = values[0].getObjectAsLong();
-			values[0] = new Var(1);
-			for (Var value : values) {
-				result = result / value.getObjectAsLong();
-			}
-			return new Var(result);
 		}
+		return new Var(result);
 	}
 
 	public static final Var abs(Var value) throws Exception {

--- a/src/test/java/br/com/cronapi/math/MathTest.java
+++ b/src/test/java/br/com/cronapi/math/MathTest.java
@@ -6,6 +6,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static cronapi.math.Operations.divisor;
 import static cronapi.math.Operations.pow;
 
 public class MathTest {
@@ -76,7 +77,14 @@ public class MathTest {
     }
 
     @Test
-    public void testDivisor() {
+    public void testDivisor() throws Exception {
+       Double expected = Var.valueOf(33.333333333333336).getObjectAsDouble();
+       Assert.assertEquals(expected, divisor(Var.valueOf(100),Var.valueOf(3)).getObjectAsDouble());
+       Assert.assertEquals(expected, divisor(Var.valueOf(100.00),Var.valueOf(3.00)).getObjectAsDouble());
+       Assert.assertEquals(expected, divisor(Var.valueOf("100"),Var.valueOf("3")).getObjectAsDouble());
+       Assert.assertEquals(expected, divisor(Var.valueOf("100.00"),Var.valueOf("3.00")).getObjectAsDouble());
+       Assert.assertEquals("Infinity", divisor(Var.valueOf("100.00"),Var.valueOf("0.00")).getObjectAsString());
+       Assert.assertEquals(Var.valueOf(0).getObjectAsDouble(), divisor(Var.valueOf("0.00"),Var.valueOf("100.00")).getObjectAsDouble());
     }
 
     @Test


### PR DESCRIPTION
FIX - função divisor para retornar o resultado como double e implementação do test case.