### PR TITLE
CRONAPP-1300  Erro ao usar bloco de atualização para alterar FK

### DIFF
--- a/src/main/java/cronapi/Var.java
+++ b/src/main/java/cronapi/Var.java
@@ -412,6 +412,8 @@ public class Var implements Comparable<Var>, JsonSerializable, OlingoJsonSeriali
       } catch (Exception e) {
         return getObjectAsRawList(LinkedList.class);
       }
+    } else if (Utils.isEntityClass(type) && _object != null && DataSource.class.isAssignableFrom(_object.getClass())) {
+      return Var.valueOf(getObjectAsDataSource().getObject()).getObject(type);
     } else {
       //create instance for Entity class
       if (Utils.isEntityClass(type) && _object != null


### PR DESCRIPTION
**Problema**

Não é permitido usar um DataSource como parâmetro Low Code

**Solução**

No cast para objeto, se o objeto for tipado utilizar o registro atual como retorno ao invés de uma entidade com o Id sendo o toString() do DataSource