### PR TITLE
CRONAPP-2586 Erro ao abrir fonte de dados pelo ODataAgent - IDE

### DIFF
--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -413,6 +413,11 @@ public class QueryManager {
 
   public static boolean isFieldAuthorized(Class clazzToCheck, String key, String method)
       throws Exception {
+
+    if (QueryManager.DISABLE_AUTH) {
+      return true;
+    }
+
     RestClient client = RestClient.getRestClient();
     if (client.getRequest() != null) {
       if (clazzToCheck != null) {
@@ -539,6 +544,11 @@ public class QueryManager {
 
   public static boolean isFieldAuthorized(JsonObject query, String field, String method)
       throws Exception {
+
+    if (QueryManager.DISABLE_AUTH) {
+      return true;
+    }
+
     if (!isNull(query.get("security"))) {
       JsonObject security = query.get("security").getAsJsonObject();
 


### PR DESCRIPTION
**Problema**
Todos os campos vem vazios abrindo fonte de dados na IDE

**Solução**
Adicionar a checagem `QueryManager.DISABLE_AUTH` nos métodos `isFieldAuthorized` para ignorar a segurança no contexto do ODataAgent