### PR TITLE
CRONAPP-2633 Fonte de dados não traz dados corretamente em view pública

### DIFF
--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -549,6 +549,22 @@ public class QueryManager {
       return true;
     }
 
+
+    //Caso o field seja o _objectKey, será verificado a permissão do verbo, pois é campo gerado dinamicamente, o usuário não seta permissão
+    //específica para esse campo na fonte de dados
+    if ("_objectKey".equalsIgnoreCase(field)) {
+      try {
+        checkSecurity(query, method, true);
+        return true;
+      }
+      catch (Exception e) {
+        if (Messages.getString("notAllowed").equalsIgnoreCase(e.getMessage()))
+          return false;
+        throw e;
+      }
+
+    }
+
     if (!isNull(query.get("security"))) {
       JsonObject security = query.get("security").getAsJsonObject();
 

--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -558,9 +558,7 @@ public class QueryManager {
         return true;
       }
       catch (Exception e) {
-        if (Messages.getString("notAllowed").equalsIgnoreCase(e.getMessage()))
-          return false;
-        throw e;
+        return false;
       }
 
     }


### PR DESCRIPTION
**Problema:** 
Fonte de dados não traz dados corretamente em view pública

**Solução:**
Caso o field seja o _objectKey, será verificado a permissão do verbo, pois é campo gerado dinamicamente, o usuário não seta permissão específica para esse campo na fonte de dados