### PR TITLE
CRONAPP-2633 Fonte de dados não traz dados corretamente em view pública

### DIFF
--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -548,9 +548,7 @@ public class QueryManager {
         return true;
       }
       catch (Exception e) {
-        if (Messages.getString("notAllowed").equalsIgnoreCase(e.getMessage()))
-          return false;
-        throw e;
+        return false;
       }
 
     }

--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -539,6 +539,22 @@ public class QueryManager {
 
   public static boolean isFieldAuthorized(JsonObject query, String field, String method)
       throws Exception {
+
+    //Caso o field seja o _objectKey, será verificado a permissão do verbo, pois é campo gerado dinamicamente, o usuário não seta permissão
+    //específica para esse campo na fonte de dados
+    if ("_objectKey".equalsIgnoreCase(field)) {
+      try {
+        checkSecurity(query, method, true);
+        return true;
+      }
+      catch (Exception e) {
+        if (Messages.getString("notAllowed").equalsIgnoreCase(e.getMessage()))
+          return false;
+        throw e;
+      }
+
+    }
+
     if (!isNull(query.get("security"))) {
       JsonObject security = query.get("security").getAsJsonObject();
 


### PR DESCRIPTION
**Problema:** 
Fonte de dados não traz dados corretamente em view pública

**Solução:**
Caso o field seja o _objectKey, será verificado a permissão do verbo, pois é campo gerado dinamicamente, o usuário não seta permissão específica para esse campo na fonte de dados