### PR TITLE
CRONAPP-2675  Gerar jar de um sistema criado com o Cronapp e rodar

### DIFF
--- a/src/main/java/cronapi/rest/ImportBlocklyREST.java
+++ b/src/main/java/cronapi/rest/ImportBlocklyREST.java
@@ -36,10 +36,10 @@ public class ImportBlocklyREST {
 
   private static boolean isValidApiPath(Path path) {
     var pathString = path.toString();
-    return API_PATHS.stream().anyMatch(pathString::contains);
+    return API_PATHS.stream().noneMatch(pathString::contains);
   }
 
-  private static boolean isValidLocalePath(Path path) {
+  private static boolean isValidLocalePath(String path) {
     return path.startsWith("locale") && path.endsWith(".json");
   }
 
@@ -53,14 +53,15 @@ public class ImportBlocklyREST {
     }
 
     try (var stream = Files.walk(i18nPath)) {
-      stream.filter(ImportBlocklyREST::isValidLocalePath)
+      stream
+          .map(path -> path.getFileName().toString())
+          .filter(ImportBlocklyREST::isValidLocalePath)
           .forEach(ImportBlocklyREST::addLocale);
     }
   }
 
-  private static void addLocale(Path path) {
-    var pathString = path.toString();
-    String localeName = pathString.substring(7, pathString.length() - 5);
+  private static void addLocale(String path) {
+    String localeName = path.substring(7, path.length() - 5);
     fillLanguageSet(localeName);
   }
 


### PR DESCRIPTION
**Problema**
- Fora do jar não listava locales
- Não estava listando as cronapis dos projetos

**Solução**
- Relativizar o caminho dos locales antes de processar
- Inverter a condição de validar o caminho da cronapi