### PR TITLE
CRONAPP-2763 - Após gerar um relatorio a sessao EntityManager que fica em cache é fechada

### DIFF
--- a/src/main/java/cronapi/database/TransactionManager.java
+++ b/src/main/java/cronapi/database/TransactionManager.java
@@ -44,7 +44,7 @@ public class TransactionManager {
     String namespace = domainClass.getPackage().getName().replace(".entity", "");
     if (mapNamespace != null && cache) {
       EntityManager emNamespace = mapNamespace.get(namespace);
-      if (emNamespace != null) {
+      if (emNamespace != null && emNamespace.isOpen()) {
         return emNamespace;
       }
     }


### PR DESCRIPTION
CRONAPP-2763 - Após gerar um relatorio a sessao EntityManager que fica em cache é fechada