### PR TITLE
CRONAPP-2791 Flush extra na função Inserir do Bloco gera Locks eterno…

### DIFF
--- a/src/main/java/cronapi/database/Operations.java
+++ b/src/main/java/cronapi/database/Operations.java
@@ -176,7 +176,6 @@ public class Operations {
         ds.insert();
         ds.updateFields(params);
         ds.save();
-        ds.flush();
     }
 
     public static void insert(Var entity, Var object) {
@@ -184,7 +183,6 @@ public class Operations {
             DataSource ds = new DataSource(entity.getObjectAsString());
             ds.insert(object.getObjectAsMap());
             Object saved = ds.save();
-            ds.flush();
             object.updateWith(saved);
         }
     }


### PR DESCRIPTION
**Problema:**
Gerando lock no banco.

**Solução:**
Removido o flush (Apesar de teoricamente isso não causar lock, mas estava acontecendo, algum bug do eclipselink)