### PR TITLE
CRONAPP-2895 [Câmara] ObjectKey não é criado corretamente com campo i…

### DIFF
--- a/src/main/java/cronapi/Var.java
+++ b/src/main/java/cronapi/Var.java
@@ -1305,6 +1305,8 @@ public class Var implements Comparable<Var>, JsonSerializable, OlingoJsonSeriali
       _type = Type.DATETIME;
     } else if (_object instanceof Long) {
       _type = Type.INT;
+    } else if (_object instanceof Short) {
+      _type = Type.INT;
     } else if (_object instanceof Integer) {
       _type = Type.INT;
       _object = Long.valueOf((Integer) _object);


### PR DESCRIPTION
**Problema:**
Var não identificava o tipo Short

**Solução:**
Adicionado o tipo Short no inferType