### PR TITLE
CRONAPP-2916 - Chamada GET retorna lista vazia no Bloco do Tipo Server

### DIFF
--- a/src/main/java/cronapi/util/Operations.java
+++ b/src/main/java/cronapi/util/Operations.java
@@ -954,4 +954,9 @@ public class Operations {
 
     }
   }
+
+  @CronapiMetaData(type = "function", name = "{{getApplicationId}}", nameTags = {"application", "id"}, description = "{{getApplicationIdDescription}}", returnType = ObjectType.STRING)
+  public static Var getApplicationId() {
+    return Var.valueOf(AppConfig.getApplicationId());
+  }
 }

--- a/src/main/java/cronapi/util/Operations.java
+++ b/src/main/java/cronapi/util/Operations.java
@@ -546,7 +546,10 @@ public class Operations {
           paramsData.add(new BasicNameValuePair(Var.valueOf(entry.getKey()).getObjectAsString(),
               Var.valueOf(entry.getValue()).getObjectAsString()));
         });
-        URI uri = new URIBuilder(httpMethod.getURI()).addParameters(paramsData).build();
+        URI uri = httpMethod.getURI();
+        if (paramsData != null && !paramsData.isEmpty()) {
+          uri = new URIBuilder(httpMethod.getURI()).addParameters(paramsData).build();
+        }
         httpMethod.setURI(uri);
       }
       httpResponse = httpClient.execute(httpMethod);
@@ -588,7 +591,10 @@ public class Operations {
           httpEntityEnclosingRequestBase.setEntity(postToData);
         }
       } else {
-        URI uri = new URIBuilder(httpMethod.getURI()).addParameters(bothDataList).build();
+        URI uri = httpMethod.getURI();
+        if (bothDataList != null && !bothDataList.isEmpty()) {
+          uri = new URIBuilder(httpMethod.getURI()).addParameters(bothDataList).build();
+        }
         httpMethod.setURI(uri);
       }
       httpResponse = httpClient.execute(httpMethod);
@@ -947,10 +953,5 @@ public class Operations {
       logManager.insert(auditLog);
 
     }
-  }
-
-  @CronapiMetaData(type = "function", name = "{{getApplicationId}}", nameTags = {"application", "id"}, description = "{{getApplicationIdDescription}}", returnType = ObjectType.STRING)
-  public static Var getApplicationId() {
-    return Var.valueOf(AppConfig.getApplicationId());
   }
 }


### PR DESCRIPTION
https://cronapp.atlassian.net/browse/CRONAPP-2916

### Problema:
Requisição GET para a API-Docente com os parâmetros incluidos na URI não retorna dados caso tenha caracteres especiais, como o simbolo do grau.

### Solução:
Adicionado condição para quando os parâmetros estiverem na URI, ignorar a adição de parâmetros no URIBuilder, pois, o array estará vazio.