### PR TITLE
CRONAPP-2958 Falha ao usar S3 como "imagem no cloud"

### DIFF
--- a/src/main/java/cronapi/cloud/S3Service.java
+++ b/src/main/java/cronapi/cloud/S3Service.java
@@ -54,7 +54,7 @@ public final class S3Service implements CloudService {
 
         getClient().putObject(request);
 
-        fileObject.setFileDirectUrl("http://" + fieldData.data.id() + "/" + AppConfig.guid() + fileObject.getFileName());
+        fileObject.setFileDirectUrl("https://s3.amazonaws.com/" + fieldData.data.id() + "/" + AppConfig.guid() + fileObject.getFileName());
 
       } catch (Throwable e) {
         log.error(e.getMessage(), e);


### PR DESCRIPTION
**Problema:**
A url armazenada do s3 (atalho do bucket) não era com SSL, o chrome não exibe mais urls que não sejam https dentro de aplicações executando em https.

**Solução:**
Gravar a url base do s3, que utiliza ssl.