### PR TITLE
CRONAPP-3249 ObjectKey não é gerado corretamente

### DIFF
--- a/src/main/java/cronapi/database/DataSource.java
+++ b/src/main/java/cronapi/database/DataSource.java
@@ -461,7 +461,17 @@ public class DataSource implements JsonSerializable {
         if (!isForeignKey) {
           return sub.get(mapping.getInternalName());
         } else {
-          return sub.get(mapping.getInternalName().substring(mapping.getInternalName().indexOf(".")+1));
+          Object result = sub.get(mapping.getInternalName().substring(mapping.getInternalName().indexOf(".")+1));
+          if (result != null)
+            return result;
+          if (obj.getClass().isArray()) {
+            for (Object objCheck: (Object[]) obj) {
+              sub = Var.valueOf(objCheck);
+              result = sub.get(mapping.getInternalName().substring(mapping.getInternalName().indexOf(".")+1));
+              if (result != null)
+                return result;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
**Problema:**
Não consegue montar o objectkey para exibição na consulta, porque o mesmo vinha dentro de um array.

**Solução:**
Necessário iterar o array para pegar o conteúdo do objeto correto.