### PR TITLE
CRONAPP-3201 - Recurso para de funcionar ao ser publicado fora do CRONAPP

### DIFF
--- a/src/main/java/cronapi/report/ReportService.java
+++ b/src/main/java/cronapi/report/ReportService.java
@@ -413,7 +413,16 @@ public class ReportService {
                 pdfExportSettings.setEmbeddedFonts(true);
                 pdfExportSettings.setStandardPdfFonts(true);
                 pdfExportSettings.setCompressed(true);
-                StiExportManager.exportPdf(stiReport, pdfExportSettings, outputStream);
+                try {
+                  StiExportManager.exportPdf(stiReport, pdfExportSettings, outputStream);
+                } catch (Exception e) {
+                  // Due to Font issues sometimes it is necessary to disable
+                  // PdfACompliance and EmbeddedFonts in order to not run the renderFontTable -> ReduceFontSize methods
+                  pdfExportSettings.setPdfACompliance(false);
+                  pdfExportSettings.setEmbeddedFonts(false);
+                  // Retry to export the PDF without the PdfACompliance
+                  StiExportManager.exportPdf(stiReport, pdfExportSettings, outputStream);
+                }
               } else if ("html".equals(type)) {
                   StiHtmlExportSettings htmlExportSettings = new  StiHtmlExportSettings();
                   htmlExportSettings.setEncoding(Charset.defaultCharset());


### PR DESCRIPTION
Solução
Em alguns casos específicos o uso de algumas fontes em componentes que precisarão sofrer redução devido ao tamanho do conteúdo não são reduzidos corretamente gerando uma exceção ao tentar embutir a fonte no documento.

https://forum.stimulsoft.com/viewtopic.php?t=55177