### PR TITLE
CRONAPP-3197 Bloco servidor "Gerar Relatório" não aceita parâmetro da…

### DIFF
--- a/src/main/java/cronapi/report/ReportService.java
+++ b/src/main/java/cronapi/report/ReportService.java
@@ -472,13 +472,15 @@ public class ReportService {
 
   void exportStimulsoftReportToFile(StiReport stiReport, File file, Map<String, String> parameters, String type, Boolean isLegacyReport) {
     try {
-      stiReport.getDataSources().forEach(stiDataSource -> {
-        if (stiDataSource instanceof StiODataSource) {
-          StiODataSource stiODataSource = (StiODataSource) stiDataSource;
-          String query = bindParameters(stiODataSource.getQuery(), parameters);
-          stiODataSource.setQuery(query);
-        }
-      });
+      if (stiReport.getDataSources() != null) {
+        stiReport.getDataSources().forEach(stiDataSource -> {
+          if (stiDataSource instanceof StiODataSource) {
+            StiODataSource stiODataSource = (StiODataSource) stiDataSource;
+            String query = bindParameters(stiODataSource.getQuery(), parameters);
+            stiODataSource.setQuery(query);
+          }
+        });
+      }
 
       stiReport.getDictionary().getVariables().forEach((c) -> {
         c.setValue(parameters.get(c.name));

--- a/src/main/java/cronapi/report/ReportService.java
+++ b/src/main/java/cronapi/report/ReportService.java
@@ -472,19 +472,17 @@ public class ReportService {
 
   void exportStimulsoftReportToFile(StiReport stiReport, File file, Map<String, String> parameters, String type, Boolean isLegacyReport) {
     try {
-      if (isLegacyReport) {
-        stiReport.getDataSources().forEach(stiDataSource -> {
-          if (stiDataSource instanceof StiODataSource) {
-            StiODataSource stiODataSource = (StiODataSource) stiDataSource;
-            String query = bindParameters(stiODataSource.getQuery(), parameters);
-            stiODataSource.setQuery(query);
-          }
-        });
-      } else {
-        stiReport.getDictionary().getVariables().forEach((c) -> {
-          c.setValue(parameters.get(c.name));
-        });
-      }
+      stiReport.getDataSources().forEach(stiDataSource -> {
+        if (stiDataSource instanceof StiODataSource) {
+          StiODataSource stiODataSource = (StiODataSource) stiDataSource;
+          String query = bindParameters(stiODataSource.getQuery(), parameters);
+          stiODataSource.setQuery(query);
+        }
+      });
+
+      stiReport.getDictionary().getVariables().forEach((c) -> {
+        c.setValue(parameters.get(c.name));
+      });
 
       stiReport.Render();
 


### PR DESCRIPTION
**Solução:**
Necessário mais uma alteração em develop, pois o codigo estava mais a frente e fazia verificação por relatório antigo o que não foi necessário em support/2.7.x