### PR TITLE
CRONAPP-3284 Obtendo o GUID pelo arquivo e não usando o customId

### DIFF
--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -128,7 +128,7 @@ public class QueryManager {
               try (InputStreamReader reader = new InputStreamReader(stream)) {
                 JsonElement jsonElement = new JsonParser().parse(reader);
                 JsonObject object = jsonElement.getAsJsonObject();
-                result.add(object.get("customId").getAsString(), object);
+                result.add(file.replace(".datasource.json","").replace("META-INF/datasources/",""), object);
               }
             } catch (Exception e) {
               log.debug(e.getMessage(), e);


### PR DESCRIPTION
**Problema:**
Se tivesse uma customquery com o mesmo nome da entidade quebra
**Solução:**
Obtendo o GUID pelo arquivo e não usando o customId