### PR TITLE
CRONAPP-3364 Valor nulo sendo colocado como "00" em campos de tipos n…

### DIFF
--- a/src/main/java/cronapi/database/Operations.java
+++ b/src/main/java/cronapi/database/Operations.java
@@ -156,7 +156,7 @@ public class Operations {
             "{{datasource}}", "{{fieldName}}", "{{fieldValue}}"}, paramsType = {ObjectType.DATASET, ObjectType.STRING,
             ObjectType.STRING}, returnType = ObjectType.VOID)
     public static void updateField(Var ds, Var fieldName, Var fieldValue) {
-        ds.setField(fieldName.getObjectAsString(), fieldValue.getObjectAsString());
+        ds.setField(fieldName.getObjectAsString(), fieldValue);
     }
 
     @CronapiMetaData(type = "function", name = "{{datasourceGetActiveData}}", nameTags = {"getElement",


### PR DESCRIPTION
**Problema:**
Estava passando o parametro com asString, perdia o valor null do _object

**Solução:**
Passando o objeto VAR para que se mantenha valor null do _object