### PR TITLE
CRONAPP-3432 - Bloco Extrair texto com Exp. Regular do tipo Servidor não esta retornando valor.

### DIFF
--- a/src/main/java/cronapi/regex/Operations.java
+++ b/src/main/java/cronapi/regex/Operations.java
@@ -29,40 +29,68 @@ public class Operations {
     @CronapiMetaData(type = "function", name = "{{extractTextWithRegex}}", nameTags = { "extractTextWithRegex" },
             description = "{{extractTextWithRegexDescription}}", params = { "{{text}}", "{{regex}}", "{{flag}}" },
             paramsType = { ObjectType.STRING, ObjectType.STRING, ObjectType.OBJECT}, returnType = ObjectType.LIST)
-    public static final Var extractTextWithRegex(Var text, Var regex, @ParamMetaData(type = ObjectType.OBJECT, description = "{{flag}}", blockType = "util_dropdown",
+    public static final Var extractTextWithRegexUnscape(Var text, Var regex, @ParamMetaData(type = ObjectType.OBJECT, description = "{{flag}}", blockType = "util_dropdown",
             keys = {"CASE_INSENSITIVE", "MULTILINE", "DOTALL", "UNICODE_CASE", "CANON_EQ", "UNIX_LINES", "LITERAL", "UNICODE_CHARACTER_CLASS", "COMMENTS"},
             values = {"{{CASE_INSENSITIVE}}", "{{MULTILINE}}", "{{DOTALL}}", "{{UNICODE_CASE}}", "{{CANON_EQ}}", "{{UNIX_LINES}}", "{{LITERAL}}", "{{UNICODE_CHARACTER_CLASS}}", "{{COMMENTS}}"}) Var flags) throws Exception{
 
         if(Var.valueOf(regex).isEmptyOrNull()) return Var.newList();
 
-        Pattern pattern = getPattern(regex, flags);
+        Pattern pattern = getPattern(regex, flags, false);
 
         return getMatcherResults(pattern, text);
 
     }
 
-    @CronapiMetaData(type = "function", name = "{{validateTextWithRegex}}", nameTags = { "validateTextWithRegex"},
-            description = "{{validateTextWithRegexDescription}}", params = { "{{text}}", "{{regex}}", "{{flag}}" },
-            paramsType = { ObjectType.STRING, ObjectType.STRING, ObjectType.OBJECT}, returnType = ObjectType.BOOLEAN)
-    public static final Var validateTextWithRegex(Var text, Var regex, @ParamMetaData(type = ObjectType.OBJECT, description = "{{flag}}", blockType = "util_dropdown",
-            keys = {"CASE_INSENSITIVE", "MULTILINE", "DOTALL", "UNICODE_CASE", "CANON_EQ", "UNIX_LINES", "LITERAL", "UNICODE_CHARACTER_CLASS", "COMMENTS"},
-            values = {"{{CASE_INSENSITIVE}}", "{{MULTILINE}}", "{{DOTALL}}", "{{UNICODE_CASE}}", "{{CANON_EQ}}", "{{UNIX_LINES}}", "{{LITERAL}}", "{{UNICODE_CHARACTER_CLASS}}", "{{COMMENTS}}"}) Var flags) throws Exception{
+    @Deprecated
+    public static final Var extractTextWithRegex(Var text, Var regex, Var flags) throws Exception{
+
+      if(Var.valueOf(regex).isEmptyOrNull()) return Var.newList();
+
+      Pattern pattern = getPattern(regex, flags, true);
+
+      return getMatcherResults(pattern, text);
+
+    }
+
+    @Deprecated
+    public static final Var validateTextWithRegex(Var text, Var regex, Var flags) throws Exception{
 
 
         if(Var.valueOf(regex).isEmptyOrNull()) return Var.VAR_FALSE;
 
-        Pattern pattern = getPattern(regex, flags);
+        Pattern pattern = getPattern(regex, flags, true);
 
         return existsMatches(pattern, text);
 
 
     }
 
-    private static Pattern getPattern(Var regex, Var flags) throws Exception {
+  @CronapiMetaData(type = "function", name = "{{validateTextWithRegex}}", nameTags = { "validateTextWithRegex"},
+      description = "{{validateTextWithRegexDescription}}", params = { "{{text}}", "{{regex}}", "{{flag}}" },
+      paramsType = { ObjectType.STRING, ObjectType.STRING, ObjectType.OBJECT}, returnType = ObjectType.BOOLEAN)
+  public static final Var validateTextWithRegexUnscape(Var text, Var regex, @ParamMetaData(type = ObjectType.OBJECT, description = "{{flag}}", blockType = "util_dropdown",
+      keys = {"CASE_INSENSITIVE", "MULTILINE", "DOTALL", "UNICODE_CASE", "CANON_EQ", "UNIX_LINES", "LITERAL", "UNICODE_CHARACTER_CLASS", "COMMENTS"},
+      values = {"{{CASE_INSENSITIVE}}", "{{MULTILINE}}", "{{DOTALL}}", "{{UNICODE_CASE}}", "{{CANON_EQ}}", "{{UNIX_LINES}}", "{{LITERAL}}", "{{UNICODE_CHARACTER_CLASS}}", "{{COMMENTS}}"}) Var flags) throws Exception{
+
+
+    if(Var.valueOf(regex).isEmptyOrNull()) return Var.VAR_FALSE;
+
+    Pattern pattern = getPattern(regex, flags, false);
+
+    return existsMatches(pattern, text);
+
+
+  }
+
+    private static Pattern getPattern(Var regex, Var flags, boolean unescape) throws Exception {
 
         if(Var.valueOf(flags).isNull()){
 
-            return Pattern.compile(org.apache.commons.lang3.StringEscapeUtils.unescapeJava( regex.getObjectAsString()));
+            if (unescape) {
+              return Pattern.compile(org.apache.commons.lang3.StringEscapeUtils.unescapeJava( regex.getObjectAsString()));
+            } else {
+              return Pattern.compile(regex.getObjectAsString());
+            }
 
         }else{
 
@@ -72,7 +100,12 @@ public class Operations {
                 throw new Exception(Messages.getString("flagRegexError"));
 
 
-            return Pattern.compile(org.apache.commons.lang3.StringEscapeUtils.unescapeJava(regex.getObjectAsString()), patternFlag);
+            if (unescape) {
+              return Pattern.compile(org.apache.commons.lang3.StringEscapeUtils.unescapeJava(regex.getObjectAsString()), patternFlag);
+            } else {
+              return Pattern.compile(regex.getObjectAsString(), patternFlag);
+            }
+
         }
     }
 

--- a/src/main/java/cronapi/validation/Operations.java
+++ b/src/main/java/cronapi/validation/Operations.java
@@ -43,7 +43,7 @@ public class Operations {
             description = "{{validateEmailDescription}}", params = {"{{email}}"},
             paramsType = {ObjectType.STRING}, returnType = ObjectType.BOOLEAN)
     public static final Var validateEmail(Var email) throws Exception{
-        return cronapi.regex.Operations.validateTextWithRegex(email, new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("^[\\w\\.-]+@([\\w\\-]+\\.)+[A-Z]{2,4}$")),
+        return cronapi.regex.Operations.validateTextWithRegexUnscape(email, new Var("^[\\w\\.-]+@([\\w\\-]+\\.)+[A-Z]{2,4}$"),
                 new Var("CASE_INSENSITIVE"));
     }
 

--- a/src/test/java/br/com/cronapi/regex/RegexTest.java
+++ b/src/test/java/br/com/cronapi/regex/RegexTest.java
@@ -31,40 +31,40 @@ public class RegexTest {
 
     @Test
     public void extractNullTextShouldBeReturnEmptyList() throws Exception{
-        Var result = Operations.extractTextWithRegex(Var.VAR_NULL, Var.VAR_NULL, Var.VAR_NULL);
+        Var result = Operations.extractTextWithRegexUnscape(Var.VAR_NULL, Var.VAR_NULL, Var.VAR_NULL);
         Assert.assertTrue(result.getObjectAsList().isEmpty());
 
     }
 
     @Test
     public void extractEmptyTextShouldBeReturnEmptyList() throws Exception{
-        Var result = Operations.extractTextWithRegex(Var.VAR_EMPTY, Var.VAR_NULL, Var.VAR_NULL);
+        Var result = Operations.extractTextWithRegexUnscape(Var.VAR_EMPTY, Var.VAR_NULL, Var.VAR_NULL);
         Assert.assertTrue(result.getObjectAsList().isEmpty());
     }
 
 
     @Test
     public void extractTextShouldBeReturnListOfList() throws Exception{
-        Var result  = Operations.extractTextWithRegex(new Var(texto1), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w*)\\$(\\w*)")), Var.VAR_NULL);
+        Var result  = Operations.extractTextWithRegexUnscape(new Var(texto1), new Var("(\\w*)\\$(\\w*)"), Var.VAR_NULL);
         Assert.assertTrue(((result.getObjectAsList().get(0)) instanceof  List));
 
-        Var result2 = Operations.extractTextWithRegex(new Var(texto2), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w{3,})")), Var.VAR_NULL);
+        Var result2 = Operations.extractTextWithRegexUnscape(new Var(texto2), new Var("(\\w{3,})"), Var.VAR_NULL);
         Assert.assertTrue(((result2.getObjectAsList().get(0)) instanceof  List));
     }
 
     @Test
     public void verifyListSize() throws Exception{
-        Var result  = Operations.extractTextWithRegex(new Var(texto1), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w*)\\$(\\w*)")), Var.VAR_NULL);
+        Var result  = Operations.extractTextWithRegexUnscape(new Var(texto1), new Var("(\\w*)\\$(\\w*)"), Var.VAR_NULL);
         Assert.assertEquals(result.getObjectAsList().size(), 3);
 
-        Var result2 = Operations.extractTextWithRegex(new Var(texto2), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w{3,})")), Var.VAR_NULL);
+        Var result2 = Operations.extractTextWithRegexUnscape(new Var(texto2), new Var("(\\w{3,})"), Var.VAR_NULL);
         Assert.assertEquals(result2.getObjectAsList().size(), 4);
     }
 
     @Test
     public void extractTextWithMultipleFlags() throws Exception{
 
-        Var result  = Operations.extractTextWithRegex(new Var(texto3),
+        Var result  = Operations.extractTextWithRegexUnscape(new Var(texto3),
                 new Var("^T.*e$"), new Var(Arrays.asList("CASE_INSENSITIVE","MULTILINE")));
         Assert.assertEquals(result.getObjectAsList().size(), 2);
     }
@@ -72,39 +72,39 @@ public class RegexTest {
 
     @Test
     public void compareExtractText() throws Exception{
-        Var result  = Operations.extractTextWithRegex(new Var(texto1), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w*)\\$(\\w*)")), Var.VAR_NULL);
+        Var result  = Operations.extractTextWithRegexUnscape(new Var(texto1), new Var("(\\w*)\\$(\\w*)"), Var.VAR_NULL);
         Assert.assertEquals(((List) ((result.getObjectAsList().get(0)))).get(0), "estude");
         Assert.assertEquals(((List) ((result.getObjectAsList().get(2)))).get(1), "demais");
 
-        Var result2 = Operations.extractTextWithRegex(new Var(texto2), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("(\\w{3,})")), Var.VAR_NULL);
+        Var result2 = Operations.extractTextWithRegexUnscape(new Var(texto2), new Var("(\\w{3,})"), Var.VAR_NULL);
         Assert.assertEquals(((List) ((result2.getObjectAsList().get(0)))).get(0), "junit");
         Assert.assertEquals(((List) ((result2.getObjectAsList().get(3)))).get(0), "demais");
     }
 
     @Test
     public void validateTextNullShouldBeReturnFalse()  throws Exception{
-            Assert.assertFalse(Operations.validateTextWithRegex(Var.VAR_NULL, Var.VAR_NULL, Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(Var.VAR_NULL, Var.VAR_NULL, Var.VAR_NULL).getObjectAsBoolean());
     }
 
     @Test
     public void validateTextEmptyShouldBeReturnFalse()  throws Exception {
-            Assert.assertFalse(Operations.validateTextWithRegex(Var.VAR_EMPTY, Var.VAR_NULL, Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(Var.VAR_EMPTY, Var.VAR_NULL, Var.VAR_NULL).getObjectAsBoolean());
     }
 
 
     @Test
     public void validateTextWithoutFlagShouldBeReturnTrue()  throws Exception{
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("123"), new Var(org.apache.commons.lang3.StringEscapeUtils.escapeJava("^\\d\\d\\d$")), Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("123"), new Var("^\\d\\d\\d$"), Var.VAR_NULL).getObjectAsBoolean());
     }
 
     @Test
     public void validateTextCaseInsensitiveShouldBeReturnTrue() throws Exception{
 
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("ABC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("AbC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("abc"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("aBc"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
-            Assert.assertTrue(Operations.validateTextWithRegex(new Var("abC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("ABC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("AbC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("abc"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("aBc"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
+            Assert.assertTrue(Operations.validateTextWithRegexUnscape(new Var("abC"), new Var("^abc$"), new Var("CASE_INSENSITIVE")).getObjectAsBoolean());
 
     }
 
@@ -112,7 +112,7 @@ public class RegexTest {
     @Test
     public void validateFlagShouldBeReturnException(){
         try {
-            Assert.assertFalse(Operations.validateTextWithRegex(new Var("ABC"), new Var("^abc$"), new Var("ABC")).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(new Var("ABC"), new Var("^abc$"), new Var("ABC")).getObjectAsBoolean());
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), Messages.getString("flagRegexError"));
         }
@@ -121,10 +121,10 @@ public class RegexTest {
 
     @Test
     public void validateTextWithoutCaseInsensitiveShouldBeReturnFalse() throws Exception {
-            Assert.assertFalse(Operations.validateTextWithRegex(new Var("ABC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
-            Assert.assertFalse(Operations.validateTextWithRegex(new Var("AbC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
-            Assert.assertFalse(Operations.validateTextWithRegex(new Var("aBc"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
-            Assert.assertFalse(Operations.validateTextWithRegex(new Var("abC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(new Var("ABC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(new Var("AbC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(new Var("aBc"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
+            Assert.assertFalse(Operations.validateTextWithRegexUnscape(new Var("abC"), new Var("^abc$"), Var.VAR_NULL).getObjectAsBoolean());
 
     }
 


### PR DESCRIPTION
Problema: expressão regular não estava trazendo valores
Solução: encontrado erro de entendimento na função, onde ela necessitava que o usuário passasse caracteres com escape. Para não quebrar quem já usa, foi depreciada a função anterior e escrita uma nova que não necessita de escape.