### PR TITLE
CRONAPP-3440 - Permitir renomear parâmetros de bloco sem afetar eventos

### DIFF
--- a/src/main/java/cronapi/ClientCommand.java
+++ b/src/main/java/cronapi/ClientCommand.java
@@ -1,5 +1,6 @@
 package cronapi;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.olingo.odata2.api.ClientCallback;
 
 import java.util.LinkedList;
@@ -7,7 +8,8 @@ import java.util.List;
 
 public class ClientCommand {
   private Var function;
-  private List<Var> params = new LinkedList<Var>();
+  private List<Var> params = new LinkedList<>();
+  private List<Var> names = new LinkedList<>();
 
   public ClientCommand(String function) {
     this.function = Var.valueOf(function);
@@ -15,7 +17,15 @@ public class ClientCommand {
 
   public void addParam(Object... values) {
     for (Object o : values) {
-      params.add(Var.valueOf(o));
+      if (o instanceof Var) {
+        Var objectVar = (Var) o;
+        if (!StringUtils.isEmpty(objectVar.getId())) {
+          names.add(Var.valueOf(objectVar.getId()));
+        }
+        params.add(Var.valueOf(objectVar.getObject()));
+      } else {
+        params.add(Var.valueOf(o));
+      }
     }
   }
 
@@ -33,6 +43,14 @@ public class ClientCommand {
 
   public void setParams(List<Var> params) {
     this.params = params;
+  }
+
+  public List<Var> getNames() {
+    return names;
+  }
+
+  public void setNames(List<Var> names) {
+    this.names = names;
   }
 
   public ClientCallback toClientCallback() {

--- a/src/main/java/cronapi/ParamMetaData.java
+++ b/src/main/java/cronapi/ParamMetaData.java
@@ -19,5 +19,7 @@ public @interface ParamMetaData {
   
   String[] keys() default "";
   String[] values() default "";
+
+  String id() default "";
   
 }

--- a/src/main/java/cronapi/QueryManager.java
+++ b/src/main/java/cronapi/QueryManager.java
@@ -319,11 +319,7 @@ public class QueryManager {
             .valueOf(event.get("blocklyClass").getAsString() + ":" + event.get("blocklyMethod")
                 .getAsString());
         try {
-          if (query.getAsJsonArray("queryParamsValues") != null && query.getAsJsonArray("queryParamsValues").size() > 0) {
-            return callBlocly(event, name, ds, keys, entityName, eventName);
-          } else {
-            return Operations.callBlockly(name, Var.valueOf(ds));
-          }
+          return callBlocly(event, name, ds, keys, entityName, eventName);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
@@ -348,8 +344,11 @@ public class QueryManager {
           }
           customValues.put("entityName", Var.valueOf(entityName));
           customValues.put("eventName", Var.valueOf(eventName));
-
-          params[i] = parseExpressionValue(ds, param.get("value"), customValues);
+          String id = null;
+          if (!isNull(param.get("id"))) {
+            id = param.get("id").getAsString();
+          }
+          params[i] = parseExpressionValue(id, ds, param.get("value"), customValues);
 
         }
 
@@ -378,7 +377,11 @@ public class QueryManager {
           for (int i = 0; i < bloclyParams.size(); i++) {
             JsonObject param = bloclyParams.get(i).getAsJsonObject();
             customValues.put("eventName", Var.valueOf(eventName));
-            params[i] = parseExpressionValue(null, param.get("value"), customValues);
+            String id = null;
+            if (!isNull(param.get("id"))) {
+              id = param.get("id").getAsString();
+            }
+            params[i] = parseExpressionValue(id, null, param.get("value"), customValues);
           }
         }
 
@@ -485,7 +488,7 @@ public class QueryManager {
             return Var.VAR_NULL;
           }
 
-          return parseExpressionValue(null, ((JsonObject) prv).get("fieldValue"), customValues);
+          return parseExpressionValue(null, null, ((JsonObject) prv).get("fieldValue"), customValues);
         }
       }
     }
@@ -1030,7 +1033,7 @@ public class QueryManager {
     return result;
   }
 
-  public static Var parseExpressionValue(Object ds, JsonElement element, Map<String, Var> customValues) {
+  public static Var parseExpressionValue(String id, Object ds, JsonElement element, Map<String, Var> customValues) {
     Var value = Var.VAR_NULL;
     if (!isNull(element)) {
       if (element.isJsonPrimitive()) {
@@ -1079,7 +1082,7 @@ public class QueryManager {
       }
     }
 
-    return value;
+    return id != null ? Var.valueOf(id, value) : value;
   }
 
   private static Var processTemplate(String templateStr, Object data) {
@@ -1099,7 +1102,7 @@ public class QueryManager {
   }
 
   public static Var parseExpressionValue(JsonElement element) {
-    return parseExpressionValue(null, element, null);
+    return parseExpressionValue(null, null, element, null);
   }
 
   public static void addCalcFields(JsonObject query, DataSource ds) {

--- a/src/main/java/cronapi/Var.java
+++ b/src/main/java/cronapi/Var.java
@@ -148,6 +148,9 @@ public class Var implements Comparable<Var>, JsonSerializable, OlingoJsonSeriali
    */
   public Var(String id, Object object) {
     this.id = id;
+    if (object instanceof Var) {
+      object = ((Var) object).getObject();
+    }
     setObject(object);
   }
 

--- a/src/main/java/cronapi/util/Operations.java
+++ b/src/main/java/cronapi/util/Operations.java
@@ -313,8 +313,16 @@ public class Operations {
     Var[] callParams = params;
 
     boolean namedParams = false;
+    boolean hasIds = params.length > 0;
 
-    if (params.length > 0 && methodToCall.getParameterCount() > 0 && !StringUtils.isEmpty(params[0].getId())) {
+    for (Var param: params) {
+      if (StringUtils.isEmpty(param.getId())) {
+        hasIds = false;
+        break;
+      }
+    }
+
+    if (params.length > 0 && methodToCall.getParameterCount() > 0 && hasIds) {
       if (ReflectionUtils.getAnnotation(methodToCall.getParameters()[0], "cronapi.ParamMetaData") != null) {
         namedParams = true;
         callParams = new Var[methodToCall.getParameterCount()];

--- a/src/main/java/cronapi/util/Operations.java
+++ b/src/main/java/cronapi/util/Operations.java
@@ -324,9 +324,8 @@ public class Operations {
         int j = 0;
         for (Parameter parameter: methodToCall.getParameters()) {
           ParamMetaData annotation = (ParamMetaData) ReflectionUtils.getAnnotation(parameter, "cronapi.ParamMetaData");
-          String name = annotation.description();
           for (Var param: params) {
-            if (param.getId().equals(name)) {
+            if (param.getId().equals(annotation.description()) || param.getId().equals(annotation.id())) {
               callParams[j] = param;
               break;
             }


### PR DESCRIPTION
Problema: ao reordenar, renomear ou apagar parâmetros, o cronapp perde referências de quem chama em eventos e bloco chamando bloco
Solução: Ajustando callBlockly para aceitar ids dos parâmetros