### PR TITLE
CRONAPP-3467 - Ao criar uma nova fonte de dados, ela não é exibida na lista de origem e dados

### DIFF
--- a/src/main/java/cronapi/odata/server/ODataAgent.java
+++ b/src/main/java/cronapi/odata/server/ODataAgent.java
@@ -452,6 +452,8 @@ public class ODataAgent {
     System.out.println("Waiting for commands...");
     while (true) {
       String input = scanner.next();
+      QueryManager.JSON_CACHE.set(null);
+      QueryManager.JSON_CACHE.remove();
       if (input.startsWith("error")) {
         System.setErr(errStream);
         ODataRequestHandler.PRINT_EXCEPTION = true;


### PR DESCRIPTION
Problema: Ao criar uma nova fonte de dados, ela não é exibida na lista de origem e dados
Solução: Limpando cache do QueryManager a cada interação