### PR TITLE
Hotfix/CRONAPP-3447 Erro ao acessar página de cadastro de dados no Se…

### DIFF
--- a/src/main/java/cronapi/AppConfig.java
+++ b/src/main/java/cronapi/AppConfig.java
@@ -275,4 +275,13 @@ public class AppConfig {
     }
     return "";
   }
+
+  public static String xFrameOptions() {
+    JsonObject config = loadJSON();
+    if (!isNull(config.get("xframeOptions"))) {
+      return config.get("xframeOptions").getAsString();
+    }
+
+    return "SameOrigin";
+  }
 }


### PR DESCRIPTION
…rviços Cloud

https://cronapp.atlassian.net/browse/CRONAPP-3447

## Problema:
O problema ocorria devido as restrições de X-FrameOptions definidas como "SAMEORIGIN" por padrão no cronapp-framework-java
## Melhoria:

## Solução:
Permitir que o desenvolvedor possa configurar através da IDE qual restrição do X-FrameOptions ele quer definir no projeto.